### PR TITLE
support gpt-4o when Claude 3.5 Sonnet is not available.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "cogent",
     "displayName": "Cogent",
     "description": "Cogent is a Copilot extension that gives it agenting capabilities like executing commands, editing and reading files, and more.",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "engines": {
         "vscode": "^1.95.0"
     },


### PR DESCRIPTION
## Changes

This PR fixes #9 by implementing better error handling when Claude 3.5 Sonnet is not available.

### Implementation Details
- Add MODEL_SELECTOR constant for primary language model configuration
- Implement fallback to gpt-4o when claude-3.5-sonnet is unavailable
- Add error handling with user feedback when no language model is available
- Improve code formatting and whitespace consistency

Implementation reference:
https://github.com/chrmarti/vscode-regex/blob/24db33e1a8dbd5e31dba83c860c5b5b70aa304d1/src/chat.ts

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactoring (no functional changes, no API changes)

## Related Issues
Fixes #9 - Cannot read properties of undefined (reading 'maxInputTokens')